### PR TITLE
clarify "item in hand" control "name"

### DIFF
--- a/locale/en/inventory-tools.cfg
+++ b/locale/en/inventory-tools.cfg
@@ -55,4 +55,4 @@ btn-clear-all=Remove all filters in the current inventory
 picker-manual-inventory-sort=Manual Inventory Sort
 picker-copy-chest=Cut chest contents
 picker-paste-chest=Paste chest contents
-picker-inventory-editor=Open item inventory
+picker-inventory-editor=Open GUI for the item in hand


### PR DESCRIPTION
Clarify the next for the "picker-inventory-editor" control to make it more obvious that it will open the GUI of any item.  

Submitted because I overlooked it five times, and finally hit the source code, when looking for it.