### PR TITLE
Fix NRE in update_item_count_settings()

### DIFF
--- a/scripts/item-count.lua
+++ b/scripts/item-count.lua
@@ -40,8 +40,8 @@ local item_count_events = {
 Event.register(item_count_events, get_itemcount_counts)
 
 local function update_item_count_settings(event)
-    local player = game.players[event.player_index]
     if event.setting == 'picker-item-count' then
+        local player = game.players[event.player_index]
         local enabled = player.mod_settings['picker-item-count'].value
         local gui = get_or_create_itemcount_gui(player)
         gui.visible = enabled and player.cursor_stack.valid_for_read or false


### PR DESCRIPTION
The 'on_runtime_mod_setting_changed' event may include a nil value for 'event.player_index', which can result in a non-recoverable error when starting a new game.

I specifically observed this issue with the Project Cybersyn mod (version 1.2.13) installed.

![PIT-Error](https://user-images.githubusercontent.com/1916917/232179766-aaff6d1d-97cf-4fff-9f75-0048e9d47ff5.png)

The following series of events occurs:
1. A new game is started.
2. Cybersyn changes one of its own settings in its 'on_init' function.
3. An 'on_runtime_mod_setting_changed' event is dispatched (with a nil player_index).
4. The 'update_item_count_settings' function runs, and attempts to index an array with the nil player_index; this raises an Exception.
5. Stdlib re-raises the Exception as a non-recoverable error, since no player has been added to the game yet.

By moving the array index statement into the existing if-statement's scope, we can ensure that player_index is not nil (since Picker Inventory Tools is the only mod that should modify the 'picker-item-count' setting).
