### PR TITLE
Fix nil index crash in update_item_count_settings

### DIFF
--- a/scripts/item-count.lua
+++ b/scripts/item-count.lua
@@ -39,9 +39,10 @@ local item_count_events = {
 }
 Event.register(item_count_events, get_itemcount_counts)
 
+---@param event EventData.on_runtime_mod_setting_changed
 local function update_item_count_settings(event)
-    local player = game.players[event.player_index]
-    if event.setting == 'picker-item-count' then
+    if event.player_index ~= nil and event.setting == 'picker-item-count' then
+        local player = game.players[event.player_index]
         local enabled = player.mod_settings['picker-item-count'].value
         local gui = get_or_create_itemcount_gui(player)
         gui.visible = enabled and player.cursor_stack.valid_for_read or false


### PR DESCRIPTION
When another mod changes a global mod setting, `event.player_index` will be nil and this function will crash.

e.g. this happens:
```
The mod Project Cybersyn (1.2.16) caused a non-recoverable error.
Please report this error to the mod author.

Error while running event cybersyn::on_init()
The mod Picker Inventory Tools (1.1.15) caused a non-recoverable error.
Please report this error to the mod author.

Error while running event PickerInventoryTools::on_runtime_mod_setting_changed (ID 61)
__stdlib__/stdlib/event/event.lua:368: __PickerInventoryTools__/scripts/item-count.lua:43: bad argument #3 of 3 to '__index' (string expected, got nil)
stack traceback:
    [C]: in function 'error'
    __stdlib__/stdlib/event/event.lua:368: in function 'dispatch_event'
    __stdlib__/stdlib/event/event.lua:438: in function <__stdlib__/stdlib/event/event.lua:396>
stack traceback:
    [C]: in function '__newindex'
    __cybersyn__/scripts/main.lua:940: in function <__cybersyn__/scripts/main.lua:937>
```
when Cybersyn does this:
```lua
local setting = settings.global["cybersyn-invert-sign"]
setting.value = false
settings.global["cybersyn-invert-sign"] = setting
```